### PR TITLE
Avoid bypassing test or lint fails

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,11 +31,9 @@ jobs:
           pip install gymnasium==${{ matrix.gymnasium-version }}
 
       - name: Test with pytest
-        continue-on-error: true
         run: pytest tests -v
 
       - name: Linting check
-        continue-on-error: true
         run: |
           ruff -V
           ruff check


### PR DESCRIPTION
I accidentally set up the CI to succeed even if testing or linting fails. That is fixed here.