### PR TITLE
fix: "choices" and remove unnecessary `n_output`

### DIFF
--- a/neurogym/envs/annubes.py
+++ b/neurogym/envs/annubes.py
@@ -30,8 +30,6 @@ class AnnubesEnv(TrialEnv):
             Defaults to 100.
         tau: Time constant in ms.
             Defaults to 100.
-        n_outputs: Number of possible outputs, signaling different behavioral choices.
-            Defaults to 2.
         output_behavior: List of possible intensity values of the behavioral output. Currently only the smallest and
             largest value of this list are used.
             Defaults to [0, 1].
@@ -54,7 +52,6 @@ class AnnubesEnv(TrialEnv):
         fix_time: int = 500,
         dt: int = 100,
         tau: int = 100,
-        n_outputs: int = 2,
         output_behavior: list[float] | None = None,
         noise_std: float = 0.01,
         rewards: dict[str, float] | None = None,
@@ -77,7 +74,6 @@ class AnnubesEnv(TrialEnv):
         self.fix_time = fix_time
         self.dt = dt
         self.tau = tau
-        self.n_outputs = n_outputs
         self.output_behavior = output_behavior
         self.noise_std = noise_std
         self.random_seed = random_seed
@@ -101,7 +97,7 @@ class AnnubesEnv(TrialEnv):
         self.observation_space = ngym.spaces.Box(low=0.0, high=1.0, shape=(len(obs_space_name),), name=obs_space_name)
         # Set the name of each action value
         self.action_space = ngym.spaces.Discrete(
-            self.n_outputs,
+            n=len(self.output_behavior),
             name={"fixation": self.output_behavior[0], "choice": self.output_behavior},
         )
 

--- a/neurogym/envs/annubes.py
+++ b/neurogym/envs/annubes.py
@@ -98,7 +98,7 @@ class AnnubesEnv(TrialEnv):
         # Set the name of each action value
         self.action_space = ngym.spaces.Discrete(
             n=len(self.output_behavior),
-            name={"fixation": self.output_behavior[0], "choice": self.output_behavior},
+            name={"fixation": self.output_behavior[0], "choice": self.output_behavior[1:]},
         )
 
     def _new_trial(self) -> dict:

--- a/tests/test_annubes_env.py
+++ b/tests/test_annubes_env.py
@@ -55,8 +55,8 @@ def test_action_space(default_env, custom_env):
     assert default_env.action_space.n == 2
     assert custom_env.action_space.n == 3
 
-    assert default_env.action_space.name == {"fixation": 0, "choice": [0, 1]}
-    assert custom_env.action_space.name == {"fixation": 0, "choice": [0, 0.5, 1]}
+    assert default_env.action_space.name == {"fixation": 0, "choice": [1]}
+    assert custom_env.action_space.name == {"fixation": 0, "choice": [0.5, 1]}
 
 
 @pytest.mark.parametrize("env", ["default_env", "custom_env"])

--- a/tests/test_annubes_env.py
+++ b/tests/test_annubes_env.py
@@ -24,7 +24,6 @@ def custom_env():
         fix_time=300,
         dt=50,
         tau=80,
-        n_outputs=3,
         output_behavior=[0, 0.5, 1],
         noise_std=0.02,
         rewards={"abort": -0.2, "correct": +1.5, "fail": -0.5},


### PR DESCRIPTION
I made 2 changes to `AnnubesEnv`, both of which I am not 100% certain are correct. Please let me know if I am mistaken and I can drop the change.

- 8d11a5a: I believe that `len(output_behavior)` needs to match `n_outputs`, so I made the code read that length rather than having to define it by the user.
- d358204: In other envs (including the template one), the "choice" options of the `action_space` do not include the 0 option. Is there a reason this was different for `AnnubesEnv`?