### PR TITLE
build: use python 3.11 throughout package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,41 +1,41 @@
 name: repo-build
 
 on:
-    push:
-      paths-ignore:
-        # specific folder locations
-        - ".vscode/**"
-        - "docs/**"
-        # filetypes
-        - "**.md"
-        - "**.rst"
-        - "**.ipynb"
-        - "**.cff"
-        - "**.png"
-      branches:
-        - main
-    pull_request:
-      types: [opened, synchronize, reopened, ready_for_review]
-      paths-ignore:
-        # specific folder locations
-        - ".vscode/**"
-        - "docs/**"
-        # filetypes
-        - "**.md"
-        - "**.rst"
-        - "**.ipynb"
-        - "**.cff"
-        - "**.png"
+  push:
+    paths-ignore:
+      # specific folder locations
+      - ".vscode/**"
+      - "docs/**"
+      # filetypes
+      - "**.md"
+      - "**.rst"
+      - "**.ipynb"
+      - "**.cff"
+      - "**.png"
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      # specific folder locations
+      - ".vscode/**"
+      - "docs/**"
+      # filetypes
+      - "**.md"
+      - "**.rst"
+      - "**.ipynb"
+      - "**.cff"
+      - "**.png"
 jobs:
   build:
     if: github.event.pull_request.draft == false
     name: Build for (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
-        matrix:
-            os: ["ubuntu-latest"]
-            python-version: ["3.10", "3.11", "3.12"]
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -46,8 +46,8 @@ jobs:
       - name: Python info
         shell: bash -e {0}
         run: |
-            which python
-            python --version
+          which python
+          python --version
       - name: Upgrade pip, install dependencies and the package
         run: |
           python -m pip install --upgrade pip setuptools

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,31 +1,31 @@
 name: linting
 
 on:
-    push:
-      paths-ignore:
-        # specific folder locations
-        - ".vscode/**"
-        - "docs/**"
-        # filetypes
-        - "**.md"
-        - "**.rst"
-        - "**.ipynb"
-        - "**.cff"
-        - "**.png"
-      branches:
-        - main
-    pull_request:
-      types: [opened, synchronize, reopened, ready_for_review]
-      paths-ignore:
-        # specific folder locations
-        - ".vscode/**"
-        - "docs/**"
-        # filetypes
-        - "**.md"
-        - "**.rst"
-        - "**.ipynb"
-        - "**.cff"
-        - "**.png"
+  push:
+    paths-ignore:
+      # specific folder locations
+      - ".vscode/**"
+      - "docs/**"
+      # filetypes
+      - "**.md"
+      - "**.rst"
+      - "**.ipynb"
+      - "**.cff"
+      - "**.png"
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      # specific folder locations
+      - ".vscode/**"
+      - "docs/**"
+      # filetypes
+      - "**.md"
+      - "**.rst"
+      - "**.ipynb"
+      - "**.cff"
+      - "**.png"
 
 jobs:
   lint:

--- a/.mlc-config.json
+++ b/.mlc-config.json
@@ -1,29 +1,29 @@
 {
-    "_comment": "Markdown Link Checker configuration, see https://github.com/gaurav-nelson/github-action-markdown-link-check and https://github.com/tcort/markdown-link-check",
-    "ignorePatterns": [
-      {
-        "pattern": "^http://localhost"
-      },
-      {
-        "pattern": "^https://doi.org/<replace-with-created-DOI>"
-      },
-      {
-        "pattern": "^https://github.com/.*/settings/secrets/actions$"
-      },
-      {
-        "pattern": "^https://github.com/organizations/.*/repositories/new"
-      },
-      {
-        "pattern": "^https://test.pypi.org"
-      },
-      {
-        "pattern": "^https://bestpractices.coreinfrastructure.org/projects/<replace-with-created-project-identifier>"
-      },
-      {
-        "pattern": "^https://readthedocs.org/dashboard/import.*"
-      }
-    ],
-    "replacementPatterns": [],
-    "retryOn429": true,
-    "timeout": "20s"
-  }
+  "_comment": "Markdown Link Checker configuration, see https://github.com/gaurav-nelson/github-action-markdown-link-check and https://github.com/tcort/markdown-link-check",
+  "ignorePatterns": [
+    {
+      "pattern": "^http://localhost"
+    },
+    {
+      "pattern": "^https://doi.org/<replace-with-created-DOI>"
+    },
+    {
+      "pattern": "^https://github.com/.*/settings/secrets/actions$"
+    },
+    {
+      "pattern": "^https://github.com/organizations/.*/repositories/new"
+    },
+    {
+      "pattern": "^https://test.pypi.org"
+    },
+    {
+      "pattern": "^https://bestpractices.coreinfrastructure.org/projects/<replace-with-created-project-identifier>"
+    },
+    {
+      "pattern": "^https://readthedocs.org/dashboard/import.*"
+    }
+  ],
+  "replacementPatterns": [],
+  "retryOn429": true,
+  "timeout": "20s"
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,53 +1,52 @@
 {
-    "creators": [
-
-        {
-            "affiliation": "Institut d'Investigacions Biomèdiques August Pi i Sunyer, Istituto Italiano di Tecnologia",
-            "name": "Manuel Molano Mazon",
-            "orcid": "0000-0002-9140-3571"
-        },
-        {
-            "affiliation": "Columbia University, Massachusetts Institute of Technology, New York University, Peking University, Simons Foundation, Yale University",
-            "name": "Guangyu Robert Yang",
-            "orcid": "0000-0002-8919-4248"
-        },
-        {
-            "name": "Marta Fradera"
-        },
-        {
-            "affiliation": "IDIBAPS, Institut d'Investigacions Biomèdiques August Pi i Sunyer, Universitat Autònoma de Barcelona, Universitat Autònoma de Barcelona Institut de Neurociències",
-            "name": "Jordi Pastor-Ciurana",
-            "orcid": "0000-0002-3050-1012"
-        },
-        {
-            "affiliation": "New York University",
-            "name": "Jeremy Forest",
-            "orcid": "0000-0002-8486-5559"
-        },
-        {
-            "affiliation": "National Institute of Health, Peking University, Shanghai Jiao Tong University, University of Minnesota, University of Rochester",
-            "name": "Ru-Yuan Zhang",
-            "orcid": "0000-0002-0654-715X"
-        },
-        {
-        "affiliation": "Netherlands eScience Center, Amsterdam, The Netherlands",
-        "name": "Giulia Crocioni",
-        "orcid": "0000-0002-0823-0121"
-        },
-        {
-        "affiliation": "Netherlands eScience Center, Amsterdam, The Netherlands",
-        "name": "Dani L. Bodor",
-        "orcid": "0000-0003-2109-2349"
-        },
-        {
-        "affiliation": "University of Amsterdam, Amsterdam, NL",
-        "name": "Jorge Mejias",
-        "orcid": "0000-0002-8096-4891"
-        }
-    ],
-    "keywords": ["neuroscience", "neural networks", "reinforcement learning"],
-    "license": {
-      "id": "MIT"
+  "creators": [
+    {
+      "affiliation": "Institut d'Investigacions Biomèdiques August Pi i Sunyer, Istituto Italiano di Tecnologia",
+      "name": "Manuel Molano Mazon",
+      "orcid": "0000-0002-9140-3571"
     },
-    "title": "NeuroGym"
-  }
+    {
+      "affiliation": "Columbia University, Massachusetts Institute of Technology, New York University, Peking University, Simons Foundation, Yale University",
+      "name": "Guangyu Robert Yang",
+      "orcid": "0000-0002-8919-4248"
+    },
+    {
+      "name": "Marta Fradera"
+    },
+    {
+      "affiliation": "IDIBAPS, Institut d'Investigacions Biomèdiques August Pi i Sunyer, Universitat Autònoma de Barcelona, Universitat Autònoma de Barcelona Institut de Neurociències",
+      "name": "Jordi Pastor-Ciurana",
+      "orcid": "0000-0002-3050-1012"
+    },
+    {
+      "affiliation": "New York University",
+      "name": "Jeremy Forest",
+      "orcid": "0000-0002-8486-5559"
+    },
+    {
+      "affiliation": "National Institute of Health, Peking University, Shanghai Jiao Tong University, University of Minnesota, University of Rochester",
+      "name": "Ru-Yuan Zhang",
+      "orcid": "0000-0002-0654-715X"
+    },
+    {
+      "affiliation": "Netherlands eScience Center, Amsterdam, The Netherlands",
+      "name": "Giulia Crocioni",
+      "orcid": "0000-0002-0823-0121"
+    },
+    {
+      "affiliation": "Netherlands eScience Center, Amsterdam, The Netherlands",
+      "name": "Dani L. Bodor",
+      "orcid": "0000-0003-2109-2349"
+    },
+    {
+      "affiliation": "University of Amsterdam, Amsterdam, NL",
+      "name": "Jorge Mejias",
+      "orcid": "0000-0002-8096-4891"
+    }
+  ],
+  "keywords": ["neuroscience", "neural networks", "reinforcement learning"],
+  "license": {
+    "id": "MIT"
+  },
+  "title": "NeuroGym"
+}

--- a/neurogym/utils/info.py
+++ b/neurogym/utils/info.py
@@ -85,7 +85,7 @@ def all_tags(verbose=0):
             env = ngym.make(env_name)
             metadata = env.metadata
             tags += metadata.get("tags", [])
-        except BaseException as e:  # noqa: BLE001, PERF203 # FIXME: unclear which error is expected here.
+        except BaseException as e:  # noqa: BLE001 # FIXME: unclear which error is expected here.
             print("Failure in ", env_name)
             print(e)
     tags = set(tags)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "numpy",
@@ -45,7 +44,7 @@ keywords = [
 license = { file = "LICENSE" }
 name = "neurogym"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 version = "0.0.1"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ build-backend = "setuptools.build_meta"
 [project]
 authors = [
     { name = "Manuel Molano Mazon", email = "manuelmolanomazon@gmail.com" },
-    { name = "Guangyu Robert Yang", email = "gyyang.neuro@gmail.com" } ,
+    { name = "Guangyu Robert Yang", email = "gyyang.neuro@gmail.com" },
     { name = "Giulia Crocioni", email = "g.crocioni@esciencecenter.nl" },
     { name = "Dani Bodor", email = "d.bodor@esciencecenter.nl" },
-    { name = "Jorge Mejias", email = "j.f.mejias@uva.nl"},
+    { name = "Jorge Mejias", email = "j.f.mejias@uva.nl" },
     { name = "Marta Fradera" },
-    { name = "Jordi Pastor-Ciurana"},
-    { name = "Jeremy Forest"},
-    { name = "Ru-Yuan Zhang"}
+    { name = "Jordi Pastor-Ciurana" },
+    { name = "Jeremy Forest" },
+    { name = "Ru-Yuan Zhang" },
 ]
 classifiers = [
     "Intended Audience :: Developers",
@@ -32,9 +32,16 @@ dependencies = [
     "gymnasium==0.29.*",
     "matplotlib",
     "stable-baselines3>=2.3.2",
-    "scipy"]
+    "scipy",
+]
 description = "NeuroGym: Gymnasium-style Cognitive Neuroscience Tasks"
-keywords = ["neuroscience", "neural networks", "supervised learning", "reinforcement learning", "synthetic data"]
+keywords = [
+    "neuroscience",
+    "neural networks",
+    "supervised learning",
+    "reinforcement learning",
+    "synthetic data",
+]
 license = { file = "LICENSE" }
 name = "neurogym"
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py310"
+target-version = "py311"
 line-length = 120
 output-format = "concise"
 exclude = ["*.ipynb"]


### PR DESCRIPTION
I've specified use of python 3.11 (or higher for pyproject.toml) throughout the package. I think we are not really doing anything to the README or docs at the moment, so haven't touched any installation instructions.

As I was editing these, there were also some formatting changes (to non *.py files) that VS code automatically implemented. These formatting settings are stored in the .vscode file. @gcroci2 , could you check whether you have the [prettier extension](esbenp.prettier-vscode) installed, which should auto-format such files upon saving.
