### PR TITLE
feature: add range functionality to `fix_time`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,6 @@ class YourTask(ngym.PeriodEnv):
 
 ```
 
-
-
-
 ### Authors
 * Contact
 

--- a/debug.py
+++ b/debug.py
@@ -1,0 +1,6 @@
+import neurogym as ngym
+from neurogym.envs.annubes import AnnubesEnv
+
+env = AnnubesEnv(fix_time=("until", 15000))
+# env = AnnubesEnv(fix_time=500)
+env.reset()

--- a/debug.py
+++ b/debug.py
@@ -1,6 +1,0 @@
-import neurogym as ngym
-from neurogym.envs.annubes import AnnubesEnv
-
-env = AnnubesEnv(fix_time=("until", 15000))
-# env = AnnubesEnv(fix_time=500)
-env.reset()

--- a/neurogym/core.py
+++ b/neurogym/core.py
@@ -120,7 +120,7 @@ class TrialEnv(BaseEnv):
         msg = "_new_trial is not defined by user."
         raise NotImplementedError(msg)
 
-    def _step(self, action) -> NoReturn:  # noqa: ARG002
+    def _step(self, _action) -> NoReturn:
         """Private interface for the environment.
 
         Receives an action and returns a new state, a reward, a flag variable

--- a/neurogym/core.py
+++ b/neurogym/core.py
@@ -312,9 +312,7 @@ class TrialEnv(BaseEnv):
 
         if duration is None:
             duration = self.sample_time(period)
-            self._duration[period] = duration
-        else:
-            self._duration[period] = duration
+        self._duration[period] = duration
 
         if after is not None:
             start = self.end_t[after] if isinstance(after, str) else after

--- a/neurogym/core.py
+++ b/neurogym/core.py
@@ -104,6 +104,7 @@ class TrialEnv(BaseEnv):
         self._tmax = 0  # Length of each trial
 
         self._top = self
+        self._duration = {}
 
     def __str__(self) -> str:
         """Information about task."""
@@ -305,6 +306,9 @@ class TrialEnv(BaseEnv):
 
         if duration is None:
             duration = self.sample_time(period)
+            self._duration[period] = duration
+        else:
+            self._duration[period] = duration
 
         if after is not None:
             start = self.end_t[after] if isinstance(after, str) else after

--- a/neurogym/core.py
+++ b/neurogym/core.py
@@ -255,6 +255,10 @@ class TrialEnv(BaseEnv):
             elif dist == "until":
                 # set period duration such that self.t_end[period] = args
                 t = args - self.tmax
+                if t < 0:
+                    msg = f"""Invalid 'until' time for period {period}. Current max time: {self.tmax},
+                    Requested end time: {args}"""
+                    raise ValueError(msg)
             else:
                 msg = f"Distribution {dist} not found."
                 raise ValueError(msg)

--- a/neurogym/core.py
+++ b/neurogym/core.py
@@ -256,8 +256,10 @@ class TrialEnv(BaseEnv):
                 # set period duration such that self.t_end[period] = args
                 t = args - self.tmax
                 if t < 0:
-                    msg = f"""Invalid 'until' time for period {period}. Current max time: {self.tmax},
-                    Requested end time: {args}"""
+                    msg = (
+                        f"Invalid 'until' time for period {period}. Current max time: {self.tmax},",
+                        f"Requested end time: {args}",
+                    )
                     raise ValueError(msg)
             else:
                 msg = f"Distribution {dist} not found."

--- a/neurogym/envs/annubes.py
+++ b/neurogym/envs/annubes.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 
 import neurogym as ngym
@@ -24,7 +26,18 @@ class AnnubesEnv(TrialEnv):
             Defaults to 0.5.
         fix_intensity: Intensity of input signal during fixation.
             Defaults to 0.
-        fix_time: Fixation time in ms. Note that the duration of each input and output signal is increased by this time.
+        fix_time: Fixation time specification. Can be one of the following:
+            - A number (int or float): Fixed duration in milliseconds.
+            - A callable: Function that returns the duration when called.
+            - A list of numbers: Random choice from the list.
+            - A tuple specifying a distribution:
+                - ("uniform", min, max): Uniform distribution between min and max.
+                - ("choice", [options]): Random choice from the given options.
+                - ("truncated_exponential", [parameters]): Truncated exponential distribution.
+                - ("constant", value): Always returns the given value.
+                - ("until", end_time): Sets duration to reach the specified end time.
+            The final duration is rounded down to the nearest multiple of the simulation timestep (dt).
+            Note that the duration of each input and output signal is increased by this time.
             Defaults to 500.
         dt: Time step in ms.
             Defaults to 100.
@@ -49,7 +62,7 @@ class AnnubesEnv(TrialEnv):
         stim_time: int = 1000,
         catch_prob: float = 0.5,
         fix_intensity: float = 0,
-        fix_time: int = 500,
+        fix_time: Any = 500,
         dt: int = 100,
         tau: int = 100,
         output_behavior: list[float] | None = None,

--- a/tests/test_annubes_env.py
+++ b/tests/test_annubes_env.py
@@ -42,7 +42,7 @@ def custom_env():
         (("choice", [300, 400, 500]), np.integer),  # Choice from list
         (("truncated_exponential", (300, 500, 400)), int),  # Truncated exponential
         (("constant", 500), int),  # Constant value
-        # (("until", 1000), int),  # Until specified time
+        (("until", 15000), int),  # Until specified time
     ],
 )
 def test_fix_time_types(fix_time, expected_type):
@@ -86,11 +86,6 @@ def test_fix_time_types(fix_time, expected_type):
         assert (
             env._duration["fixation"] == fix_time[1]
         ), f"Expected fix_time to be {fix_time[1]}, but got {env._duration['fixation']}"
-    # Check if the sampled fix_time is less than or equal to the given end time
-    elif isinstance(fix_time, tuple) and fix_time[0] == "until":
-        assert (
-            env._duration["fixation"] - env._duration <= fix_time[1]
-        ), f"Expected fix_time to be less than or equal to {fix_time[1]}, but got {env._duration['fixation']}"
 
     # For callable fix_time, check if it's actually called
     if callable(fix_time):

--- a/tests/test_annubes_env.py
+++ b/tests/test_annubes_env.py
@@ -31,6 +31,77 @@ def custom_env():
     )
 
 
+@pytest.mark.parametrize(
+    ("fix_time", "expected_type"),
+    [
+        (500, int),  # Fixed integer duration
+        (500.0, float),  # Fixed float duration
+        (lambda: 500, int),  # Callable returning fixed duration
+        ([300, 400, 500], np.integer),  # List of durations for random choice
+        (("uniform", (300, 500)), float),  # Uniform distribution
+        (("choice", [300, 400, 500]), np.integer),  # Choice from list
+        (("truncated_exponential", (300, 500, 400)), int),  # Truncated exponential
+        (("constant", 500), int),  # Constant value
+        # (("until", 1000), int),  # Until specified time
+    ],
+)
+def test_fix_time_types(fix_time, expected_type):
+    """Test various types of fix_time specifications."""
+    env = AnnubesEnv(fix_time=fix_time)
+    # Be sure that at least one trial is run to sample the fix_time
+    env.reset()
+
+    # Check if the sampled fix_time is of the expected type
+    assert isinstance(
+        env._duration["fixation"],
+        expected_type,
+    ), f"Expected fix_time to be of type {expected_type}, but got {type(env._duration['fixation'])}"
+
+    # Check if the sampled fix_time is in the given list of values
+    if isinstance(fix_time, list):
+        assert (
+            env._duration["fixation"] in fix_time
+        ), f"Expected fix_time to be one of {fix_time}, but got {env._duration['fixation']}"
+    # Check if the sampled fix_time is in the given range
+    elif isinstance(fix_time, tuple) and fix_time[0] == "uniform":
+        fix_time_range = fix_time[1]
+        assert (
+            fix_time_range[0] <= env._duration["fixation"] <= fix_time_range[1]
+        ), f"""Expected fix_time to be between {fix_time_range[0]} and {fix_time_range[1]},
+        but got {env._duration['fixation']}"""
+    # Check if the sampled fix_time is in the given list of values
+    elif isinstance(fix_time, tuple) and fix_time[0] == "choice":
+        assert (
+            env._duration["fixation"] in fix_time[1]
+        ), f"Expected fix_time to be one of {fix_time[1]}, but got {env._duration['fixation']}"
+    # Check if the sampled fix_time is in the given range
+    elif isinstance(fix_time, tuple) and fix_time[0] == "truncated_exponential":
+        fix_time_range = fix_time[1]
+        assert (
+            fix_time_range[0] <= env._duration["fixation"] <= fix_time_range[1]
+        ), f"""Expected fix_time to be between {fix_time_range[0]} and {fix_time_range[1]},
+        but got {env._duration['fixation']}"""
+    # Check if the sampled fix_time is the given constant value
+    elif isinstance(fix_time, tuple) and fix_time[0] == "constant":
+        assert (
+            env._duration["fixation"] == fix_time[1]
+        ), f"Expected fix_time to be {fix_time[1]}, but got {env._duration['fixation']}"
+    # Check if the sampled fix_time is less than or equal to the given end time
+    elif isinstance(fix_time, tuple) and fix_time[0] == "until":
+        assert (
+            env._duration["fixation"] - env._duration <= fix_time[1]
+        ), f"Expected fix_time to be less than or equal to {fix_time[1]}, but got {env._duration['fixation']}"
+
+    # For callable fix_time, check if it's actually called
+    if callable(fix_time):
+        assert env._duration["fixation"] == 500, f"Expected fix_time to be 500, but got {env._duration['fixation']}"
+
+    # Ensure the sampled time is a multiple of dt
+    assert (
+        env._duration["fixation"] % env.dt == 0
+    ), f"Expected fix_time to be a multiple of dt ({env.dt}), but got {env._duration['fixation']}"
+
+
 def test_observation_space(default_env, custom_env):
     """Test the observation space of both default and custom environments.
 


### PR DESCRIPTION
The functionality was already there for all the times defined in the `self.timing` attribute, so for `fix_time` as well. I've added the doc string and the tests.

There is an issue for the "until" functionality, but it's not trivial so I've opened a separate issue for it (#64).